### PR TITLE
build: introduce CMake based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+#[[
+This source file is part of the DocC open source project
+
+Copyright (c) 2024 Apple Inc. and the DocC project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+cmake_minimum_required(VERSION 3.24)
+
+project(LMDB
+  LANGUAGES C)
+
+# Set the build artifact directories to ensure that the generated products are
+# colocated and findable for wiring up into the test suites across repositories.
+# This pattern is applied to all Swift and LLVM repositories.
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/Sources/CLMDB/CMakeLists.txt
+++ b/Sources/CLMDB/CMakeLists.txt
@@ -1,0 +1,16 @@
+#[[
+This source file is part of the DocC open source project
+
+Copyright (c) 2024 Apple Inc. and the DocC project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(CLMDB
+  mdb.c
+  midl.c)
+target_include_directories(CLMDB PUBLIC
+  include)
+
+set_property(GLOBAL APPEND PROPERTY LMDB_EXPORTS CLMDB)

--- a/Sources/CLMDB/include/module.modulemap
+++ b/Sources/CLMDB/include/module.modulemap
@@ -1,0 +1,4 @@
+
+module CLMDB {
+  header "lmdb.h"
+}

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,10 @@
+#[[
+This source file is part of the DocC open source project
+
+Copyright (c) 2024 Apple Inc. and the DocC project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_subdirectory(CLMDB)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,19 @@
+#[[
+This source file is part of the DocC open source project
+
+Copyright (c) 2024 Apple Inc. and the DocC project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+set(LMDB_EXPORTS_FILE
+  ${CMAKE_CURRENT_BINARY_DIR}/LMDBExports.cmake)
+configure_file(LMDBConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/LMDBConfig.cmake)
+
+get_property(LMDB_EXPORTS GLOBAL PROPERTY LMDB_EXPORTS)
+export(TARGETS ${LMDB_EXPORTS}
+  NAMESPACE LMDB::
+  FILE ${LMDB_EXPORTS_FILE}
+  EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/cmake/modules/LMDBConfig.cmake.in
+++ b/cmake/modules/LMDBConfig.cmake.in
@@ -1,0 +1,12 @@
+#[[
+This source file is part of the DocC open source project
+
+Copyright (c) 2024 Apple Inc. and the DocC project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+if(NOT TARGET LMDB::CLMDB)
+  include("@LMDB_EXPORTS_FILE@")
+endif()


### PR DESCRIPTION
This adds a CMake based build for LMDB to support DocC. By using CMake for the build, we are able to reduce the overall toolchain build time by ~7% on Windows.