### PR TITLE
Cherry pick changes from IndexStoreDB's copy of LMDB

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,6 +20,12 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "CLMDB",
-            dependencies: []),
+            dependencies: [],
+            cSettings: [
+                .define("MDB_USE_POSIX_MUTEX", to: "1",
+                        // Windows does not use POSIX mutex
+                        .when(platforms: [.linux, .macOS])),
+                .define("MDB_USE_ROBUST", to: "0"),
+            ]),
     ]
 )

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -664,7 +664,7 @@ static txnid_t mdb_debug_start;
 	 *	#MDB_DUPSORT data items must fit on a node in a regular page.
 	 */
 #ifndef MDB_MAXKEYSIZE
-#define MDB_MAXKEYSIZE	 ((MDB_DEVEL) ? 0 : 511)
+#define MDB_MAXKEYSIZE	 0 // ((MDB_DEVEL) ? 0 : 511) /* use computed max by default */
 #endif
 
 	/**	The maximum size of a key we can write to the environment. */
@@ -809,11 +809,11 @@ typedef struct MDB_rxbody {
 	 *	started from so we can avoid overwriting any data used in that
 	 *	particular version.
 	 */
-	volatile txnid_t		mrb_txnid;
+	 txnid_t		mrb_txnid;
 	/** The process ID of the process owning this reader txn. */
-	volatile MDB_PID_T	mrb_pid;
+	_Atomic MDB_PID_T	mrb_pid;
 	/** The thread ID of the thread owning this txn. */
-	volatile MDB_THR_T	mrb_tid;
+	_Atomic MDB_THR_T	mrb_tid;
 } MDB_rxbody;
 
 	/** The actual reader record, with cacheline padding. */
@@ -853,12 +853,12 @@ typedef struct MDB_txbody {
 		 *	This is recorded here only for convenience; the value can always
 		 *	be determined by reading the main database meta pages.
 		 */
-	volatile txnid_t		mtb_txnid;
+	_Atomic txnid_t		mtb_txnid;
 		/** The number of slots that have been used in the reader table.
 		 *	This always records the maximum count, it is not decremented
 		 *	when readers release their slots.
 		 */
-	volatile unsigned	mtb_numreaders;
+	_Atomic unsigned	mtb_numreaders;
 #if defined(_WIN32) || defined(MDB_USE_POSIX_SEM)
 		/** Binary form of names of the reader/writer locks */
 	mdb_hash_t			mtb_mutexid;
@@ -1249,7 +1249,7 @@ typedef struct MDB_meta {
 	 *	Actually the file may be shorter if the freeDB lists the final pages.
 	 */
 	pgno_t		mm_last_pg;
-	volatile txnid_t	mm_txnid;	/**< txnid that committed this page */
+	_Atomic txnid_t	mm_txnid;	/**< txnid that committed this page */
 } MDB_meta;
 
 	/** Buffer for a stack-allocated meta page.
@@ -1510,7 +1510,7 @@ struct MDB_env {
 	unsigned int	me_os_psize;	/**< OS page size, from #GET_PAGESIZE */
 	unsigned int	me_maxreaders;	/**< size of the reader table */
 	/** Max #MDB_txninfo.%mti_numreaders of interest to #mdb_env_close() */
-	volatile int	me_close_readers;
+	_Atomic int	me_close_readers;
 	MDB_dbi		me_numdbs;		/**< number of DBs opened */
 	MDB_dbi		me_maxdbs;		/**< size of the DB table */
 	MDB_PID_T	me_pid;		/**< process ID of this env */
@@ -10111,7 +10111,7 @@ typedef struct mdb_copy {
 	/** Error code.  Never cleared if set.  Both threads can set nonzero
 	 *	to fail the copy.  Not mutex-protected, LMDB expects atomic int.
 	 */
-	volatile int mc_error;
+	_Atomic int mc_error;
 } mdb_copy;
 
 	/** Dedicated writer thread for compacting copy. */


### PR DESCRIPTION
IndexStoreDB enables thread sanitization in its builds and made several changes to its copy of LMDB in order to build:

1. Change uses of `volatile` to `_Atomic`
2. Enable POSIX mutexes on non-Windows platforms
3. Disable robust mutexes since they only apply to multi-process access of databases

IndexStoreDB also sets `MDB_MAXKEYSIZE` to 0 in order to tell LMDB to use the max computed key size.