### PR TITLE
build: enable C11 mode for the package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,5 +27,6 @@ let package = Package(
                         .when(platforms: [.linux, .macOS])),
                 .define("MDB_USE_ROBUST", to: "0"),
             ]),
-    ]
+    ],
+    cLanguageStandard: .c11
 )


### PR DESCRIPTION
This package uses `_Atomic` which is a C11 feature. Enable this explicitly in the package manifest rather than relying on the compiler to default to this language mode.