### PR TITLE
Disable the `shorten-64-to-32` warning in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
                         // Windows does not use POSIX mutex
                         .when(platforms: [.linux, .macOS])),
                 .define("MDB_USE_ROBUST", to: "0"),
+                .unsafeFlags(["-Wno-shorten-64-to-32"])
             ]),
     ]
 )


### PR DESCRIPTION
Without this flag, we get about 40 warnings when building `swift-lmdb` in Xcode. I don’t think there is an immediate plan to address them in upstream lmdb, so let’s disable them.